### PR TITLE
添加UserAgent和代理池功能

### DIFF
--- a/crawl_code.py
+++ b/crawl_code.py
@@ -1,33 +1,85 @@
+import html
 import json
-import time
+import logging
 import os
+import re
+import time
 
 import requests
-import re
-import html
 from tqdm import tqdm
 
+''' Proxy pool endpoints, powered by https://github.com/jhao104/proxy_pool'''
+''' Attention! You should have the proxy pool service running in background!
+> See the blog: https://zhuanlan.zhihu.com/p/497011455
+1. Clone the project. `git clone git@github.com:jhao104/proxy_pool.git`
+2. Run with docker! `docker-compose up -d`
+3. You will have the services powered by proxy_pool.
+> view http://127.0.0.1:5010 and see the documentation.
+'''
 
+
+def get_proxy():
+    return requests.get("http://127.0.0.1:5010/get/").json()
+
+
+def delete_proxy(proxy):
+    requests.get("http://127.0.0.1:5010/delete/?proxy={}".format(proxy))
+
+
+# User Agent for anti-spider
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.57'
+}
+MAX_RETRY_CNT = 20
 CODE_START_PATTERN = r"<pre id=\"program-source-text\" class=\"prettyprint.+?program-source\" style=\"padding: 0\.5em;\">"
 
 
 def fetch_code(contest_id, submission_id) -> str:
     url = f"https://codeforces.com/contest/{contest_id}/submission/{submission_id}"
-    response = requests.get(url=url)
-    if response.status_code != 200:
-        raise ValueError(f"Request status error, status code: {response.status_code}. "
-                         f"Request URL: {url}.")
-    content = response.text
 
-    match = re.search(CODE_START_PATTERN, content)
-    if match is None:
-        raise ValueError(f"Source code not found. url: {url}")
-    start_pos = match.end()
-    end_pos = content.find("</pre>", start_pos)
-    result = content[start_pos: end_pos]
-    code = html.unescape(result)
+    # Get the random ip proxy
+    proxy = get_proxy().get("proxy")
+    logging.info(f"Current proxy: http://{proxy}.")
+    retry_count = MAX_RETRY_CNT
+    match = None
+    code = None
+    while retry_count > 0:
+        try:
+            # use proxy ip for the access to the website
+            response = requests.get(
+                url=url, timemout=5, headers=HEADERS, proxies={"http": "http://{}".format(proxy)})
 
-    return code
+            if response.status_code != 200:
+                # renew proxy
+                delete_proxy(proxy)
+                proxy = get_proxy().get("proxy")
+                logging.info(f"Retry proxy: http://{proxy}.")
+                raise ValueError(f"Request status error, status code: {response.status_code}. "
+                                 f"Request URL: {url}.")
+            content = response.text
+
+            match = re.search(CODE_START_PATTERN, content)
+            if match is None:
+                # renew proxy
+                delete_proxy(proxy)
+                proxy = get_proxy().get("proxy")
+                logging.info(f"Retry proxy: http://{proxy}.")
+                raise ValueError(f"Source code not found. url: {url}")
+
+            start_pos = match.end()
+            end_pos = content.find("</pre>", start_pos)
+            result = content[start_pos: end_pos]
+            code = html.unescape(result)
+            return code
+
+        except Exception:
+            retry_count -= 1
+
+    # delete broken proxy ip address
+    delete_proxy(proxy)
+    raise ValueError(
+        f"Failed after {MAX_RETRY_CNT} times retry. url: {url}")
+    return None
 
 
 def main():
@@ -47,12 +99,13 @@ def main():
                 all_submissions.append(data)
 
         # crawl code from website
-        with open(os.path.join(save_code_dir, f"{lang}_code.jsonl"), mode="w", encoding="utf-8") as f:
+        with open(os.path.join(save_code_dir, f"{lang}_code.jsonl"), mode="a", encoding="utf-8", buffering=1) as f:
             for submission in all_submissions:
                 submission_id = submission["id"]
                 contest_id = submission["contest_id"]
 
-                code = fetch_code(contest_id=contest_id, submission_id=submission_id)
+                code = fetch_code(contest_id=contest_id,
+                                  submission_id=submission_id)
 
                 data = {
                     "id": submission_id,

--- a/crawl_code.py
+++ b/crawl_code.py
@@ -26,6 +26,8 @@ def delete_proxy(proxy):
     requests.get("http://127.0.0.1:5010/delete/?proxy={}".format(proxy))
 
 
+logging.basicConfig(filename="crawl.log", filemode="w", format="%(asctime)s %(name)s:%(levelname)s:%(message)s",
+                    datefmt="%d-%M-%Y %H:%M:%S", level=logging.DEBUG)
 # User Agent for anti-spider
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.57'
@@ -53,7 +55,7 @@ def fetch_code(contest_id, submission_id) -> str:
                 # renew proxy
                 delete_proxy(proxy)
                 proxy = get_proxy().get("proxy")
-                logging.info(f"Retry proxy: http://{proxy}.")
+                logging.warning(f"Retry proxy: http://{proxy}.")
                 raise ValueError(f"Request status error, status code: {response.status_code}. "
                                  f"Request URL: {url}.")
             content = response.text
@@ -63,7 +65,7 @@ def fetch_code(contest_id, submission_id) -> str:
                 # renew proxy
                 delete_proxy(proxy)
                 proxy = get_proxy().get("proxy")
-                logging.info(f"Retry proxy: http://{proxy}.")
+                logging.warning(f"Retry proxy: http://{proxy}.")
                 raise ValueError(f"Source code not found. url: {url}")
 
             start_pos = match.end()

--- a/crawl_code.py
+++ b/crawl_code.py
@@ -47,7 +47,7 @@ def fetch_code(contest_id, submission_id) -> str:
         try:
             # use proxy ip for the access to the website
             response = requests.get(
-                url=url, timemout=5, headers=HEADERS, proxies={"http": "http://{}".format(proxy)})
+                url=url, timeout=5, headers=HEADERS, proxies={"http": "http://{}".format(proxy)})
 
             if response.status_code != 200:
                 # renew proxy


### PR DESCRIPTION
目前爬取80条会block，在原有代码的基础上添加了代理池功能，以及关键的ua请求头（个人猜测是反爬的主要原因）
先在本地启动代理池服务（参见注释，[代理池开源项目](https://github.com/jhao104/proxy_pool)），然后再运行爬虫脚本，可是增大重试次数，或者去掉代理功能（可能也许没有对ip进行反爬）